### PR TITLE
 match latest W3C CG Charter template process

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,65 +416,172 @@
       Specification(s) to be developed in this group can be completed.
       </li>
     </ul>
+
+    <p class="note">Proposal used Community and Business Group Process and Patent Policy as header</p>
+
     <h2 id="process">
-      Community and Business Group Process and Patent Policy
+      Community and Business Group Process
     </h2>
-    <p>
-      The group operates under the <a href=
+
+    <p>The group operates under the <a href=
       "https://www.w3.org/community/about/agreements/">Community and Business
       Group Process</a>. Terms in this Charter that conflict with those of the
       Community and Business Group Process are void.
     </p>
-    <p>
-      As with other Community Groups, W3C seeks organizational licensing
+
+    <p class="note">Proposed charter added sentence from Web Platform Incubator
+    CG about proposals - don't think that makes sense here - Proposals in this 
+    Community Group charter are applicable Specification in the CLA</p>
+    
+    <p>As with other Community Groups, W3C seeks organizational licensing
       commitments under the <a href=
       'http://www.w3.org/community/about/agreements/cla/'>W3C Community
-      Contributor License Agreement (CLA)</a>. Proposals in this Community
-      Group charter are applicable "Specification" in the CLA. When people
+      Contributor License Agreement (CLA)</a>. When people
       request to participate without representing their organization's legal
       interests, W3C will in general approve those requests for this group with
       the following understanding: W3C will seek and expect an organizational
       commitment under the CLA starting with the individual's first request to
-      make a contribution to <a href="#deliverables">Deliverables</a>. The
+      make a contribution to a group <a href="#deliverables">Deliverable</a>. The
       section on <a href="#contrib">Contribution Mechanics</a> describes how
       W3C expects to monitor these contribution requests.
     </p>
+
+   <p class="note">Proposed charter deleted this paragraph</p>  
+    <h2 id="worklimit">
+      Work Limited to Charter Scope
+    </h2>
+    
+    <p>The group will not publish Specifications on topics other than those 
+    listed under <a href="#specifications">Specifications</a> above. 
+    See below for <a href="#charter-change">how to modify the charter</a>. 
+    </p>
+    
     <h2 id="contrib">
       Contribution Mechanics
     </h2>
+    
     <p>
-      Community Group participants agree to make contributions in the GitHub
-      repository for the project that they are interested in. This may be in
-      the form of a pull request (preferred), by raising an issue, or by adding
-      a comment to an existing issue.
+    Substantive Contributions to Specifications can only be made by Community 
+    Group Participants who have agreed to the 
+    <a href="http://www.w3.org/community/about/agreements/cla/">W3C Community
+      Contributor License Agreement (CLA)</a>. 
     </p>
+    
     <p>
-      Specifications created for proposals in the Community Group must use the
+      Specifications created in the Community Group must use the
       <a href=
       "http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">
-      W3C Software and Document License</a>.
+      W3C Software and Document License</a>.  All other documents produced 
+      by the group should use that License where possible. 
     </p>
+
+    <p class="remove">
+      {TBD: if CG doesn't use GitHub replace the remaining paragraphs in this 
+      section with: "All Contributions are made on the groups public mail list
+      or public contrib list"} 
+    </p>
+    
+    <p>
+      Community Group participants agree to make all contributions 
+      in the GitHub repo the group is using for the particular document. 
+      This may be in the form of a pull request (preferred), by raising an issue, 
+      or by adding a comment to an existing issue.
+    </p>
+
     <p>
       All Github repositories attached to the Community Group must contain a
-      copy of the <a href="CONTRIBUTING.md">CONTRIBUTING</a> and <a href=
-      "LICENSE.md">LICENSE</a> files.
+      copy of the 
+      <a href="https://github.com/w3c/licenses/blob/master/CG-CONTRIBUTING.md">CONTRIBUTING</a>
+      and <a href=
+      "https://github.com/w3c/licenses/blob/master/CG-LICENSE.md">LICENSE</a> files.
     </p>
+   <p class="note">Proposed charter deleted last section of this paragraph</p>
     <p>
-      Note: this Community Group will not use a <em>contrib</em> mailing list
-      for contributions since all contributions will be tracked via Github
-      mechanisms (e.g. pull requests).
+      Note: this Community Group will not use a contrib mailing list for contributions 
+      since all contributions will be tracked via Github mechanisms 
+      (e.g. pull requests). For the same reason, the Community Group 
+      mailing list must not be used for making or discussing substantive contributions
+      to Specifications.
     </p>
+    
+    <h2 id="transparency">
+      Transparency
+    </h2>
+    
+    <p>
+      The group will conduct all of its technical work in public. If the group 
+      uses GitHub, all technical work will occur in its GitHub repositories 
+      (and not in mailing list discussions). This is to ensure contributions 
+      can be tracked through a software tool.
+    </p>
+  
+   <p class="note">Proposed charter deleted this paragraph</p>  
+    <p>
+      Meetings may be restricted to Community Group participants, but a 
+      public summary or minutes must be posted to the group's public mailing 
+      list, or to a GitHub issue if the group uses GitHub.
+    </p>
+
+    <h2 id="decision">
+      Decision Process
+    </h2>
+    
+    <p>This group will seek to make decisions where there is consensus. 
+    Groups are free to decide how to make decisions (e.g. Participants 
+    who have earned Committer status for a history of useful contributions 
+    assess consensus, or the Chair assesses consensus, or where consensus 
+    isn't clear there is a Call for Consensus [CfC] to allow multi-day online 
+    feedback for a proposed course of action). It is expected that participants 
+    can earn Committer status through a history of valuable contributions as is 
+    common in open source projects. After discussion and due consideration of 
+    different opinions, a decision should be publicly recorded (where GitHub is 
+    used as the resolution of an Issue).
+    </p>
+    
+    <p>
+      If substantial disagreement remains (e.g. the group is divided) 
+      and the group needs to decide an Issue in order to continue to make progress, 
+      the Committers will choose an alternative that had substantial support 
+      (with a vote of Committers if necessary). Individuals who disagree 
+      with the choice are strongly encouraged to take ownership 
+      of their objection by taking ownership of an alternative fork. 
+      This is explicitly allowed (and preferred to blocking progress) 
+      with a goal of letting implementation experience inform which 
+      spec is ultimately chosen by the group to move ahead with.
+    </p>
+    
+    <p>
+      Any decisions reached at any meeting are tentative and should be 
+      recorded in a GitHub Issue for groups that use GitHub and otherwise 
+      on the group's public mail list. Any group participant may object to 
+      a decision reached at an online or in-person meeting within 7 days of 
+      publication of the decision provided that they include clear technical 
+      reasons for their objection. The Chairs will facilitate discussion to try 
+      to resolve the objection according to the <a href="#decision">decision 
+      process</a>.
+    </p>
+    
+    <p>
+      It is the Chairs' responsibility to ensure that the decision process is fair,
+      respects the consensus of the CG, and does not unreasonably favour or 
+      discriminate against any group participant or their employer.
+    </p>
+
+    
     <h2 id="chairs">
       Chair Selection
     </h2>
+
     <p>
       Participants in this group choose their Chair(s) and can replace their
       Chair(s) at any time using whatever means they prefer. However, if 5
       participants, no two from the same organisation, call for an election,
       the group must use the following process to replace any current Chair(s)
       with a new Chair, consulting the Community Development Lead on election
-      operations (e.g., voting infrastructure and using RFC 2777).
+      operations (e.g., voting infrastructure and using 
+      <a href="https://tools.ietf.org/html/rfc2777">RFC 2777</a>).
     </p>
+
     <ol>
       <li>Participants announce their candidacies. Participants have 14 days to
       announce their candidacies, but this period ends as soon as all
@@ -489,66 +596,17 @@
       break the tie. An elected Chair may appoint co-Chairs.
       </li>
     </ol>
+
     <p>
       Participants dissatisfied with the outcome of an election may ask the
       Community Development Lead to intervene. The Community Development Lead,
       after evaluating the election, may take any action including no action.
     </p>
-    <h2 id="decision">
-      Decision Process
-    </h2>
-    <p>
-      This group will seek to make decisions when there is consensus. The
-      Editor(s) of a specification will determine and record consensus
-      decisions through the specification's GitHub repo issue list with
-      assistance from the Community Group Chair(s). Members of the group may
-      reopen issues with new technical information.
-    </p>
-    <p>
-      It is the Chairs' responsibility to ensure that the decision process is
-      fair, respects the consensus of the Community Group, and does not
-      unreasonably favour or discriminate against any group participant or
-      their employer. With that said, the group favours forward motion and
-      dissent will not be allowed to block work on a specification.
-    </p>
-    <p>
-      If substantial disagreement remains (e.g. the group is divided) and there
-      is a call for assessing consensus after due consideration of different
-      opinions, the Chair should record a decision and any objections.
-      Participants may call for an online vote if they feel the Chair has not
-      accurately determined the consensus of the group or if the Chair refuses
-      to assess consensus. The call for a vote must specify the duration of the
-      vote which must be at least 7 days and should be no more than 14 days.
-      The Chair must start the vote within 7 days of the request. The decision
-      will be based on the majority of the ballots cast.
-    </p>
-    <p>
-      Initially, the Editor(s) and Chair(s) are the only Committers. It is
-      expected that participants can earn Committer status in a GitHub
-      reposiroty through a history of valuable contributions as is common in
-      open source projects.
-    </p>
-    <h2 id="transparency">
-      Transparency
-    </h2>
-    <p>
-      The group will conduct all of its technical work on its GitHub
-      repositories (and not in mailing list discussions). This is to ensure
-      contributions can be tracked and to ensure that engagement will scale to
-      a large number of proposals.
-    </p>
-    <p>
-      Any decisions reached at any meeting are tentative and should be recorded
-      in the repository issues list. Any group participant may object to a
-      decision reached at an online or in-person meeting within 7 days of
-      publication of the decision provided that they include clear technical
-      reasons for their objection. The Chairs will facilitate discussion to try
-      to resolve the objection according to the <a href="#decision">Decision
-      Process</a>.
-    </p>
+
     <h2 id="charter-change">
       Amendments to this Charter
     </h2>
+    
     <p>
       The group can decide to work on a proposed amended charter, editing the
       text using the <a href="#decision">Decision Process</a> described above.


### PR DESCRIPTION
@mfoltzgoogle  @anssiko
Cut and pasted process section from latest [W3C CG Charter template](http://w3c.github.io/cg-charter/CGCharter.html).  this proposed charter was using an older version.  Please see [https://github.com/webscreens/cg-charter/issues/11](https://github.com/webscreens/cg-charter/issues/11)

I put notes in this where the proposed charter had substantive differences.  The newer template was mostly changing the order of sections and moving paragraphs from one section to another.
